### PR TITLE
replace microcks references with apicurio + make cope snippets copy/paste friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ $ kubectl create namespace apicurio
 Then, from this repository root directory, create the specific CRDS and resources needed for Operator:
 
 ```sh
-$ kubectl create -f deploy/crd/apicuriostudios.studio.apicur.io-v1.yml
-$ kubectl create -f deploy/service_account.yaml -n apicurio 
-$ kubectl create -f deploy/role.yaml -n apicurio
-$ kubectl create -f deploy/role_binding.yaml -n apicurio
+kubectl create -f deploy/crd/apicuriostudios.studio.apicur.io-v1.yml
+kubectl create -f deploy/service_account.yaml -n apicurio 
+kubectl create -f deploy/role.yaml -n apicurio
+kubectl create -f deploy/role_binding.yaml -n apicurio
 ```
 
 Finally, deploy the operator:
 
 ```sh
-$ kubectl create -f deploy/operator.yaml -n apicurio
+kubectl create -f deploy/operator.yaml -n apicurio
 ```
 
 Wait a minute or two and check everything is running:
@@ -216,3 +216,5 @@ Produce a native container image with the name elements specified within the `po
 ```sh
 mvn package -Pnative -Dquarkus.native.container-build=true -Dquarkus.container-image.build=true
 ```
+
+> NOTE: To build a native image you must have GraalVM installed. See [here](https://quarkus.io/guides/building-native-image#graalvm) for instructions on how to set it up.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Kubernetes Operator for easy setup and management of Apicurio Studio instances.
 * [Usage](#usage)
     * [Minimalist CRD](#minimalist-crd)
     * [Complete CRD](#complete-crd)
-    * [ApicurioStudio details](#apicuriostudio-details)
+    * [Apicurio Studio details](#apicuriostudio-details)
     * [Status tracking](#status-tracking)
 * [Build](#build)
 <!--te-->
@@ -48,7 +48,7 @@ $ kubectl create -f deploy/operator.yaml -n apicurio
 Wait a minute or two and check everything is running:
 
 ```sh
-$ kubectl get pods -n microcks                                  
+$ kubectl get pods -n apicurio                                  
 NAME                                        READY     STATUS    RESTARTS   AGE
 apicurio-studio-operator-76d47d899f-2tzzm   1/1       Running   0          1m
 ```
@@ -57,11 +57,13 @@ Now just create a `ApicurioStudio` CRD!
 
 ### Via OLM add-on
 
-[Operator Lyfecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager) shoud be installed on your cluster first. Please follow this [guideline](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/install/install.md) to know how to proceed.
+[Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager) should be installed on your cluster first. Please follow this [guideline](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/install/install.md) to know how to proceed.
 
 You can then use the [OperatorHub.io](https://operatorhub.io) catalog of Kubernetes Operators sourced from multiple providers. It offers you an alternative way to install stable versions of Microcks using the Microcks Operator. To install Microcks from [OperatorHub.io](https://operatorhub.io), locate the *Apicurio Studio Operator* and follow the instructions provided.
 
 As an alternative, raw resources can also be found into the `/deploy/olm` directory of this repo.
+
+## Usage
 
 ### Minimalist CRD
 


### PR DESCRIPTION
- replace `microcks` references with `apicurio`
- make commands copy/paste friendly
